### PR TITLE
fixed copyfiles in npm start script

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "copyfiles -u 1 src/**/*.{jpg,js,html,css} src/*.{js,html} build && node server.js",
+    "start": "copyfiles -u 1 src/**/*.{jpg,svg,js,html,css} src/*.{js,html} build && node server.js",
     "build": "workbox inject:manifest"
   },
   "author": "",

--- a/project/package.json
+++ b/project/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "copyfiles -u 1 src/**/**/* src/**/* src/* build && node server.js",
+    "start": "copyfiles -u 1 src/**/*.{jpg,js,html,css} src/*.{js,html} build && node server.js",
     "build": "workbox inject:manifest"
   },
   "author": "",

--- a/solution/package.json
+++ b/solution/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "copyfiles -u 1 src/**/*.{jpg,js,html,css} src/*.{js,html} build && node server.js",
+    "start": "copyfiles -u 1 src/**/*.{jpg,svg,js,html,css} src/*.{js,html} build && node server.js",
     "build": "workbox inject:manifest"
   },
   "author": "",

--- a/solution/package.json
+++ b/solution/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "copyfiles -u 1 src/**/**/* src/**/* src/* build && node server.js",
+    "start": "copyfiles -u 1 src/**/*.{jpg,js,html,css} src/*.{js,html} build && node server.js",
     "build": "workbox inject:manifest"
   },
   "author": "",


### PR DESCRIPTION
added file extensions to the glob patterns in the copyfiles command to make it more robust