### PR TITLE
fix(package.json): ignore SW file during server startup

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "copyfiles -u 1 src/**/*.{jpg,svg,js,html,css} src/*.{js,html} build && node server.js",
+    "start": "copyfiles -e '**/sw.js' -u 1 src/**/*.{jpg,svg,js,html,css} src/*.{js,html} build && node server.js",
     "build": "workbox inject:manifest"
   },
   "author": "",

--- a/solution/package.json
+++ b/solution/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "copyfiles -u 1 src/**/*.{jpg,svg,js,html,css} src/*.{js,html} build && node server.js",
+    "start": "copyfiles -e '**/sw.js' -u 1 src/**/*.{jpg,svg,js,html,css} src/*.{js,html} build && node server.js",
     "build": "workbox inject:manifest"
   },
   "author": "",


### PR DESCRIPTION
Previously, running `npm run start` copied all
files from `src` to `build`, including the source
service worker file. Running `npm run build`
generated the production service worker file.

The issue was that if you generated the production
service worker, but then restarted the server
during offline testing, the server `start` process
would overwrite the production service worker file
with the `src` service worker file, so you would have
to re-`build`.

This commit updates the `start` script to ignore the
`src` service worker file. Now `start` only copies
non-SW assets, and `build` only generates the SW. The
two commands are independent.